### PR TITLE
Setting _ErrorMessage to null in order to reset it

### DIFF
--- a/Files/DataStandard/powerGateModules/Communication.psm1
+++ b/Files/DataStandard/powerGateModules/Communication.psm1
@@ -39,6 +39,8 @@ function GetPowerGateError {
 function CheckResponse($entity) {
 	if ($null -eq $entity) {
 		$entity = $false
+		Add-Member -InputObject $entity -Name "_ErrorMessage" -Value $null -MemberType NoteProperty -Force
+		
 		$pGError = GetPowerGateError
 		if ($pGError) {
 			$message = "The communication with ERP failed!`n '$pGError'"


### PR DESCRIPTION
Reproduce:
1. Open "ERP Item" tab for a entity which does not exist
1. Open "ERP Search" and search exact for a itemnumber which does not exist
1. The messagebox appears with error "Number is empty!!!"

I found out that `_ErrorMessage` was set in the Search function after calling `CheckResponse`, very interesting behaviour, the customer has ps version `5.1.18362.145`

The workaround was to reset the `_ErrorMessage`.