### PR TITLE
Typo correction

### DIFF
--- a/Files/powerGate/Modules/MaterialFunctions.psm1
+++ b/Files/powerGate/Modules/MaterialFunctions.psm1
@@ -19,7 +19,7 @@ function GetErpMaterial($number) {
 		return $erpMaterial
 	}
 	$number = $number.ToUpper()
-	$erpMaterial = Get-ERPObject -EntitySet $materialEntitySet -Key @{ Number = $number }
+	$erpMaterial = Get-ERPObject -EntitySet $materialEntitySet -Keys @{ Number = $number }
 	$erpMaterial = Edit-ResponseWithErrorMessage -Entity $erpMaterial
 	
 	Add-Member -InputObject $erpMaterial -Name "IsCreate" -Value $false -MemberType NoteProperty -Force


### PR DESCRIPTION
There was a typo in the parameter "Keys" of the Get-ERPObject Cmdlet