### PR TITLE
Initialize coolOrange only in specific apps

### DIFF
--- a/Files/powerEvents/Modules/Import.Modules.psm1
+++ b/Files/powerEvents/Modules/Import.Modules.psm1
@@ -1,12 +1,15 @@
-$initModulePath = "C:\ProgramData\coolOrange\powerGate\Modules\Initialize.psm1"
-$moduleName = [io.path]::GetFileNameWithoutExtension($initModulePath)
-if( (Get-Module -Name $moduleName) ) {
-    Remove-Module -Name $moduleName
+$allowedProcesses = @("Connectivity.VaultPro","Inventor", "Acad")
+if ($allowedProcesses -contains $processName) {
+    $initModulePath = "C:\ProgramData\coolOrange\powerGate\Modules\Initialize.psm1"
+    $moduleName = [io.path]::GetFileNameWithoutExtension($initModulePath)
+    if( (Get-Module -Name $moduleName) ) {
+        Remove-Module -Name $moduleName
+    }
+    Import-Module -Name $initModulePath -Global -Force
+    Initialize-CoolOrange
+
+    $logPath = Join-Path $env:LOCALAPPDATA "coolOrange\Projects\powerEvents.log"
+    Set-LogFilePath -Path $logPath
+
+    ConnectToErpServer
 }
-Import-Module -Name $initModulePath -Global -Force
-Initialize-CoolOrange
-
-$logPath = Join-Path $env:LOCALAPPDATA "coolOrange\Projects\powerEvents.log"
-Set-LogFilePath -Path $logPath
-
-ConnectToErpServer


### PR DESCRIPTION
As a User I want to initialize the coolOrange customization only in specific processes in order to avoid loading it in applications that are not needed and avoid longer waiting times while the template connects to ERP.

### Solution
Add a check for the process in which powerEvents is loaded in [Files/powerEvents/Modules/Import.Modules.psm1](https://github.com/coolOrangeLabs/powerGateTemplate/blob/master/Files/powerEvents/Modules/Import.Modules.psm1) e.g.:
