### PR TITLE
#190 prevent check button bug with removed items

### DIFF
--- a/Files/DataStandard/Vault.Custom/addinVault/powerGateBomTransfer.ps1
+++ b/Files/DataStandard/Vault.Custom/addinVault/powerGateBomTransfer.ps1
@@ -93,6 +93,12 @@ function Check-Boms($VaultBoms) {
     [array]::Reverse($VaultBoms)
     foreach ($vaultBom in $VaultBoms) {
 
+        foreach ($vaultBomRow in $vaultBom.Children) {
+            if ($vaultBomRow._Status -eq "Remove") {
+                Remove-BomWindowEntity -InputObject $vaultBomRow
+            }
+        }  
+
         if ($vaultBom._Status -ne "Unknown") {
             Update-BomWindowEntity -InputObject $vaultBom -Status $vaultBom._Status -StatusDetails $vaultBom.Message
 			foreach ($vaultBomRow in $vaultBom.Children) {


### PR DESCRIPTION
Explanation of the Problem: [Issue #190](https://github.com/coolOrangeLabs/powerGateTemplate/issues/190#issuecomment-1248040578)

How to test this code:

1. Direct to `Files/DataStandard/Vault.Custom/addinVault/powerGateBomTransfer.ps1`
2. Add the following 2 lines in line 101: 
```
$remove = Add-BomWindowEntity -Type BomRow -Properties @{Bom_Number = "test"} -Parent $VaultBom
Update-BomWindowEntity $remove -Status "Remove"
```
3. Open Vault, click on an .iam item, direct to the `ERP BOM` tap and click on `BOM transfer...`
4. Click Check multiple times on Check and the item with the status `remove` will appear just once.